### PR TITLE
Faculty list and detail API endpoints

### DIFF
--- a/backend/app/controllers/FacultyController.java
+++ b/backend/app/controllers/FacultyController.java
@@ -1,0 +1,72 @@
+package controllers;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import models.ResearcherInfo;
+import models.User;
+import models.rest.RESTResponse;
+import play.Logger;
+import play.mvc.Controller;
+import play.mvc.Result;
+import services.FacultyService;
+import utils.Common;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class FacultyController extends Controller {
+
+    private static final String DEFAULT_SORT = "lastName";
+
+    private final FacultyService facultyService;
+
+    @Inject
+    public FacultyController(FacultyService facultyService) {
+        this.facultyService = facultyService;
+    }
+
+    /**
+     * Lists all faculty members with name, department, research interests, and up to 5 recent publications.
+     */
+    public Result listFaculty(Optional<Integer> pageLimit, Optional<Integer> offset,
+                              Optional<String> sortCriteria) {
+        String sortOrder = Common.getSortCriteria(sortCriteria, DEFAULT_SORT);
+        try {
+            List<ResearcherInfo> facultyList = new ArrayList<>();
+            for (ResearcherInfo info : ResearcherInfo.find.query().findList()) {
+                User user = info.getUser();
+                if (user != null && user.isResearcher()) {
+                    facultyList.add(info);
+                }
+            }
+            RESTResponse response = facultyService.paginateResults(facultyList, offset, pageLimit, sortOrder);
+            return ok(response.response());
+        } catch (Exception e) {
+            Logger.error("FacultyController.listFaculty exception", e);
+            return internalServerError("Failed to retrieve faculty list.");
+        }
+    }
+
+    /**
+     * Returns the detailed profile for a single faculty member, including full publication data.
+     *
+     * @param id the user id of the faculty member
+     */
+    public Result facultyDetail(Long id) {
+        if (id == null) {
+            return Common.badRequestWrapper("Faculty id is required.");
+        }
+        try {
+            ResearcherInfo info = ResearcherInfo.find.query().where().eq("user_id", id).findOne();
+            if (info == null || info.getUser() == null || !info.getUser().isResearcher()) {
+                return notFound("Faculty member not found with id: " + id);
+            }
+            ObjectNode result = facultyService.toFacultyJson(info, true);
+            return ok(result);
+        } catch (Exception e) {
+            Logger.error("FacultyController.facultyDetail exception", e);
+            return notFound("Faculty member not found with id: " + id);
+        }
+    }
+}

--- a/backend/app/services/FacultyService.java
+++ b/backend/app/services/FacultyService.java
@@ -1,0 +1,91 @@
+package services;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import models.Author;
+import models.Paper;
+import models.ResearcherInfo;
+import models.User;
+import models.rest.RESTResponse;
+import play.libs.Json;
+import utils.Common;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class FacultyService {
+
+    private static final int MAX_RECENT_PUBLICATIONS = 5;
+
+    public RESTResponse paginateResults(List<ResearcherInfo> facultyList, Optional<Integer> offset,
+                                        Optional<Integer> pageLimit, String sortCriteria) {
+        RESTResponse response = new RESTResponse();
+        int maxRows = facultyList.size();
+        if (pageLimit.isPresent()) maxRows = pageLimit.get();
+        int startIndex = 0;
+        if (offset.isPresent()) startIndex = offset.get();
+
+        if (!facultyList.isEmpty() && startIndex >= facultyList.size())
+            startIndex = pageLimit.get() * ((facultyList.size() - 1) / pageLimit.get());
+
+        List<ResearcherInfo> paginated = Common.paginate(startIndex, maxRows, facultyList);
+        response.setTotal(facultyList.size());
+        response.setSort(sortCriteria);
+        response.setOffset(startIndex);
+        response.setItems(toJsonArray(paginated, false));
+        return response;
+    }
+
+    public ObjectNode toFacultyJson(ResearcherInfo info, boolean fullPublications) {
+        User user = info.getUser();
+        ObjectNode node = Json.newObject();
+        node.put("id", user.getId());
+        node.put("firstName", user.getFirstName() != null ? user.getFirstName() : "");
+        node.put("lastName", user.getLastName() != null ? user.getLastName() : "");
+        node.put("email", user.getEmail() != null ? user.getEmail() : "");
+        node.put("avatar", user.getAvatar() != null ? user.getAvatar() : "");
+        node.put("department", info.getDepartment() != null ? info.getDepartment() : "");
+        node.put("school", info.getSchool() != null ? info.getSchool() : "");
+        node.put("researchFields", info.getResearchFields() != null ? info.getResearchFields() : "");
+        node.put("highestDegree", info.getHighestDegree() != null ? info.getHighestDegree() : "");
+        node.put("orcid", info.getOrcid() != null ? info.getOrcid() : "");
+
+        node.set("recentPublications", buildPublications(info, fullPublications));
+        return node;
+    }
+
+    private ArrayNode buildPublications(ResearcherInfo info, boolean fullPublications) {
+        ArrayNode publications = Json.newArray();
+        Author author = info.getAuthor();
+        if (author == null || author.getPapersByAuthor() == null) return publications;
+
+        List<Paper> recent = author.getPapersByAuthor().stream()
+                .sorted((a, b) -> {
+                    String ya = a.getYear() != null ? a.getYear() : "";
+                    String yb = b.getYear() != null ? b.getYear() : "";
+                    return yb.compareTo(ya);
+                })
+                .limit(MAX_RECENT_PUBLICATIONS)
+                .collect(Collectors.toList());
+
+        for (Paper paper : recent) {
+            if (fullPublications) {
+                publications.add(Json.toJson(paper));
+            } else {
+                ObjectNode pub = Json.newObject();
+                pub.put("id", paper.getId());
+                pub.put("title", paper.getTitle() != null ? paper.getTitle() : "");
+                pub.put("year", paper.getYear() != null ? paper.getYear() : "");
+                publications.add(pub);
+            }
+        }
+        return publications;
+    }
+
+    private ArrayNode toJsonArray(List<ResearcherInfo> list, boolean fullPublications) {
+        ArrayNode array = Json.newArray();
+        for (ResearcherInfo info : list) array.add(toFacultyJson(info, fullPublications));
+        return array;
+    }
+}

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -404,6 +404,11 @@ GET           /author/topAuthors                                                
 POST          /author/linkResearchers                                                                              controllers.AuthorController.linkResearchersToAuthors(overwriteExisting: java.util.Optional[java.lang.Boolean])
 ################################## Authors #############################################################################
 
+#################################### Faculty #####################################################################
+GET           /faculty                                                                                             controllers.FacultyController.listFaculty(pageLimit: java.util.Optional[Integer], offset: java.util.Optional[Integer], sortCriteria: java.util.Optional[String])
+GET           /faculty/:id                                                                                        controllers.FacultyController.facultyDetail(id: Long)
+#################################### Faculty #####################################################################
+
 #################################### Reviewer #####################################################################
 POST          /reviewer/addReviewer                                                                                      controllers.ReviewerController.addReviewer
 GET           /reviewer/reviewerDetail/:userId                                                                           controllers.ReviewerController.reviewerDetail(userId: Long)


### PR DESCRIPTION
- Adds `GET /faculty` — paginated list of all faculty members (researchers) with name, department, school, research interests, and up to 5 recent publications (id, title, year)
- Adds `GET /faculty/:id` — full faculty profile including complete publication data for the 5 most recent papers, returns 404 for unknown or non-researcher ids
- Follows existing controller/service patterns (`AuthorController` / `AuthorService`)

## Test plan issue #5 

- [ ] `GET /faculty` returns `200` with `items`, `total`, `count`, `offset`, `limit` envelope
- [ ] Each item contains `firstName`, `lastName`, `department`, `researchFields`, and `recentPublications`
- [ ] `GET /faculty/:id` with a valid researcher id returns full profile
- [ ] `GET /faculty/:id` with an unknown id returns `404`
- [ ] `GET /faculty/:id` with a non-researcher user id returns `404`
- [ ] Publications in response are sorted newest-first and capped at 5